### PR TITLE
Clarified that Package Control is a ST add-on

### DIFF
--- a/installation.rst
+++ b/installation.rst
@@ -4,7 +4,7 @@ Installation
 ============
 |sl| itself is only a **framework** for linters. The linters are distributed as independent |st| plugins.
 
-|sl| (and the linter plugins) can be installed via |_pc| or from source. I **strongly** recommend that you use |pc|! Not only does it ease installation, but more importantly it automatically updates the plugins it installs, which ensures you will get the latest features and bug fixes.
+|sl| (and the linter plugins) can be installed via a plugin called |_pc| or from source. I **strongly** recommend that you use |pc|! Not only does it ease installation, but more importantly it automatically updates the plugins it installs, which ensures you will get the latest features and bug fixes.
 
 
 Upgrading from previous versions


### PR DESCRIPTION
Might encourage people without much Sublime Experience to click the link and install PC instead of thinking it's just an info page on Sublime's website and skip a step (like I did).

Feel free to modify the wording/reject this, but I noticed this issue and wanted to suggest a slight change!