### PR TITLE
Clarified background lint mode documentation

### DIFF
--- a/lint_modes.rst
+++ b/lint_modes.rst
@@ -13,7 +13,7 @@ There are four lint modes in |sl|: :ref:`background <background-lint-mode>`, :re
 
 Background
 ~~~~~~~~~~~
-In **background** mode, lint requests are generated for every modification of a view. This is the default mode. Remember that lint requests only trigger a lint if the associated view has not been modified when the request is pulled off the queue.
+In **background** mode, lint requests are generated for every modification of a view, as well as on file loading and saving. This is the default mode. Remember that background lint requests only trigger a lint if the associated view has not been modified when the request is pulled off the queue (see :ref:`Linting <usage-linting>`).
 
 **Pros**
 


### PR DESCRIPTION
I found the description of the 'background' lint mode kind of confusing at first. Thought this might save someone a few minutes.

1. The documentation was not explicit regarding whether linting is also triggered on file load/save when using 'background' mode. Experimenting with the plug-in indicates that it does in fact trigger a lint on save, even if the view hasn't been modified. I clarified this.

2. The documentation had mentioned something important to remember about lint request queues, which doesn't make much sense without having an understanding of how the background mode is implemented. These implementation details are described on the *Usage* page (sort of unexpected place for it), so i added a ref link to provide the necessary context.